### PR TITLE
Split out port and server from header

### DIFF
--- a/lib/http_proxy.js
+++ b/lib/http_proxy.js
@@ -72,18 +72,21 @@
       return this;
     };
     HttpProxy.prototype.outboundProxy = function(req, res, next) {
-      var passed_opts, server_host, upstream_processor, upstream_request;
+      var passed_opts, server_host, server_host_port, server_port, tmp, upstream_processor, upstream_request;
       if ((req.realHost != null)) {
-        server_host = req.realHost;
+        server_host_port = req.realHost;
       } else {
-        server_host = req.headers['host'];
+        server_host_port = req.headers['host'];
       }
+      tmp = server_host_port.split(':');
+      server_host = tmp[0];
+      server_port = tmp.length > 1 ? tmp[1] : 80;
       passed_opts = {
         method: req.method,
         path: req.url,
         host: server_host,
         headers: req.headers,
-        port: req.port
+        port: server_port
       };
       upstream_processor = function(upstream_res) {
         res.statusCode = upstream_res.statusCode;

--- a/src/http_proxy.coffee
+++ b/src/http_proxy.coffee
@@ -51,10 +51,13 @@ exports.HttpProxy = class HttpProxy extends connect.HTTPServer
 
   outboundProxy: (req, res, next) ->
     if (req.realHost?)
-      server_host = req.realHost
+      server_host_port = req.realHost
     else
-      server_host = req.headers['host']
-    passed_opts = {method:req.method, path:req.url, host:server_host, headers:req.headers, port:req.port}
+      server_host_port = req.headers['host']
+    tmp = server_host_port.split(':')
+    server_host = tmp[0]
+    server_port = if tmp.length > 1 then tmp[1] else 80
+    passed_opts = {method:req.method, path:req.url, host:server_host, headers:req.headers, port:server_port}
     upstream_processor = (upstream_res) ->
       # Helpers for easier logging upstream
       res.statusCode = upstream_res.statusCode


### PR DESCRIPTION
I was having problems proxying to a local development site running on a non-standard port (3000). I found that for some reason in http_proxy.coffee this information wasn't in req.port, but it was in req.host in the format "host:port". I added some code to parse and add the port that's inspired by code from a similar project here: https://github.com/tdebarochez/connect-cache/blob/master/lib/connect-cache.js (line 61-63)

It's my first pull request, so review carefully let me know if I messed anything up :)

-Alex
